### PR TITLE
Update day2-comms notes

### DIFF
--- a/lectures/day2-comms/day2-comms_notes.md
+++ b/lectures/day2-comms/day2-comms_notes.md
@@ -499,7 +499,7 @@ Let's create two new threads and move our publisher/subscriber code over:
 
 ```cpp=
 
-using ThreadBase = goby::middleware::SimpleThread
+using ThreadBase = goby::middleware::SimpleThread<goby3_course::config::InterThread1>;
 
 namespace goby3_course
 {


### PR DESCRIPTION
This PR patches a potential typo in the day-comms notes. Using `ThreadBase` without the _Config_ template argument throws a compilation error otherwise.

If approved, could you please update the PDF file as well? Thanks.